### PR TITLE
Technical webpack config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@
 dist/*
 build/*
 coverage
+webpack.*.js

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,7 +6,6 @@ module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
-    contentBase: './dist',
     hot: true,
     https: true,
     key: fs.readFileSync('./localhost-key.pem'),


### PR DESCRIPTION
Removes unnecessary `contentBase` in webpack dev server config.
Adds webpack config files to eslintignore configuration.